### PR TITLE
Dependencies conflict debug support (local only)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-six
-typing >= 3.6
+six >=1.9
+typing >= 3.6 ; python_version < "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -117,3 +117,11 @@ commands = python setup.py build_sphinx upload_sphinx
 [testenv:bandit]
 deps = bandit
 commands = bandit -r threaded
+
+[testenv:dep-graph]
+envdir = {toxworkdir}/dep-graph
+deps =
+    pipenv
+commands =
+    pipenv install -r {toxinidir}/build_requirements.txt --skip-lock
+    pipenv graph


### PR DESCRIPTION
typing for python < 3.7 only
Tox target `dep-graph` allows to debug dependencies conflict locally.