### PR TITLE
Update requirements and metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ threaded
 .. image:: https://coveralls.io/repos/github/python-useful-helpers/threaded/badge.svg?branch=master
     :target: https://coveralls.io/github/python-useful-helpers/threaded?branch=master
 .. image:: https://readthedocs.org/projects/threaded/badge/?version=latest
-    :target: http://threaded.readthedocs.io/
+    :target: https://threaded.readthedocs.io/
     :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/threaded.svg
     :target: https://pypi.python.org/pypi/threaded

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six >=1.10.0
-typing >= 3.6 ; python_version < "3.7"
+typing >= 3.6 ; python_version < "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,17 +5,6 @@ name = threaded
 zip_safe = False
 packages = find:
 
-# While setuptools cannot deal with pre-installed incompatible versions,
-# setting a lower bound is not harmful - it makes error messages cleaner. DO
-# NOT set an upper bound on setuptools, as that will lead to uninstallable
-# situations as progressive releases of projects are done.
-# Blacklist setuptools 34.0.0-34.3.2 due to https://github.com/pypa/setuptools/issues/951
-# Blacklist setuptools 36.2.0 due to https://github.com/pypa/setuptools/issues/1086
-setup_requires =
-    setuptools >= 21.0.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0
-
-python_requires = >=2.7.5,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
-
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [metadata]
 name = threaded
+project_urls =
+    Bug Tracker = https://github.com/python-useful-helpers/threaded/issues
+    Documentation = https://threaded.readthedocs.io/
 
 [options]
 zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -249,12 +249,26 @@ setup_args = dict(
         for name, email in variables['__maintainers__'].items()
     ),
     url=variables['__url__'],
+    project_urls={
+        "Bug Tracker": "https://github.com/python-useful-helpers/threaded/issues",
+        "Documentation": "https://threaded.readthedocs.io/",
+    },
     version=variables['__version__'],
     license=variables['__license__'],
     description=variables['__description__'],
     long_description=long_description,
     classifiers=classifiers,
     keywords=keywords,
+    python_requires='>=2.7.5,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    # While setuptools cannot deal with pre-installed incompatible versions,
+    # setting a lower bound is not harmful - it makes error messages cleaner. DO
+    # NOT set an upper bound on setuptools, as that will lead to uninstallable
+    # situations as progressive releases of projects are done.
+    # Blacklist setuptools 34.0.0-34.3.2 due to https://github.com/pypa/setuptools/issues/951
+    # Blacklist setuptools 36.2.0 due to https://github.com/pypa/setuptools/issues/1086
+    setup_requires="setuptools >= 21.0.0,!=24.0.0,"
+                   "!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,"
+                   "!=36.2.0",
     extras_require={
         ':python_version == "2.7"': [
             'futures>=3.1',

--- a/setup.py
+++ b/setup.py
@@ -249,10 +249,6 @@ setup_args = dict(
         for name, email in variables['__maintainers__'].items()
     ),
     url=variables['__url__'],
-    project_urls={
-        "Bug Tracker": "https://github.com/python-useful-helpers/threaded/issues",
-        "Documentation": "https://threaded.readthedocs.io/",
-    },
     version=variables['__version__'],
     license=variables['__license__'],
     description=variables['__description__'],


### PR DESCRIPTION
typing: python <3.8 (due to still not completed)
setup_requires & python_requires in setup.py due to old setuptools logic
project_urls for packaging