### PR TITLE
Py34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 os: linux
 python:
+- 3.4
 - 3.5
 - 3.6
 - &mainstream_python 3.7-dev

--- a/README.rst
+++ b/README.rst
@@ -37,12 +37,13 @@ Pros:
 
 ::
 
+    Python 3.4
     Python 3.5
     Python 3.6
     Python 3.7
     PyPy3 3.5+
 
-.. note:: For python 2.7/3.4/PyPy you can use versions 1.x.x
+.. note:: For python 2.7/PyPy you can use versions 1.x.x
 
 Decorators:
 

--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,7 @@ classifiers = [
 
     'License :: OSI Approved :: Apache Software License',
 
+    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ setup_args = dict(
     long_description=long_description,
     classifiers=classifiers,
     keywords=keywords,
-    python_requires='>=3.5',
+    python_requires='>=3.4',
     # While setuptools cannot deal with pre-installed incompatible versions,
     # setting a lower bound is not harmful - it makes error messages cleaner. DO
     # NOT set an upper bound on setuptools, as that will lead to uninstallable

--- a/test/async_syntax/conftest.py
+++ b/test/async_syntax/conftest.py
@@ -1,0 +1,7 @@
+"""Test rules."""
+import sys
+
+
+def pytest_ignore_collect(path, config):
+    """Ignore sources for python 3.4."""
+    return sys.version_info < (3, 5)

--- a/test/async_syntax/test_gevent_threadpooled_async.py
+++ b/test/async_syntax/test_gevent_threadpooled_async.py
@@ -1,0 +1,38 @@
+#    Copyright 2017 Alexey Stepanov aka penguinolog
+##
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import threading
+import unittest
+
+try:
+    import gevent
+    import gevent.threadpool
+except ImportError:
+    gevent = None
+
+import threaded
+
+
+@unittest.skipIf(gevent is None, 'No gevent')
+class TestThreadPooled(unittest.TestCase):
+    def tearDown(self):
+        threaded.GThreadPooled.shutdown()
+
+    def test_thread_pooled_default_async(self):
+        @threaded.gthreadpooled
+        async def test():
+            return threading.current_thread().name
+
+        pooled_name = test().wait()
+        self.assertNotEqual(pooled_name, threading.current_thread().name)

--- a/test/async_syntax/test_pooled_async.py
+++ b/test/async_syntax/test_pooled_async.py
@@ -26,8 +26,7 @@ class TestThreadPooled(unittest.TestCase):
 
     def test_thread_pooled_default(self):
         @threaded.threadpooled
-        @asyncio.coroutine
-        def test():
+        async def test():
             return threading.current_thread().name
 
         pooled_name = concurrent.futures.wait([test()])
@@ -35,8 +34,7 @@ class TestThreadPooled(unittest.TestCase):
 
     def test_thread_pooled_construct(self):
         @threaded.threadpooled()
-        @asyncio.coroutine
-        def test():
+        async def test():
             return threading.current_thread().name
 
         pooled_name = concurrent.futures.wait([test()])
@@ -46,8 +44,7 @@ class TestThreadPooled(unittest.TestCase):
         loop = asyncio.get_event_loop()
 
         @threaded.threadpooled(loop_getter=loop)
-        @asyncio.coroutine
-        def test():
+        async def test():
             return threading.current_thread().name
 
         pooled_name = loop.run_until_complete(asyncio.wait_for(test(), 1))
@@ -57,8 +54,7 @@ class TestThreadPooled(unittest.TestCase):
         loop = asyncio.get_event_loop()
 
         @threaded.threadpooled(loop_getter=asyncio.get_event_loop)
-        @asyncio.coroutine
-        def test():
+        async def test():
             return threading.current_thread().name
 
         pooled_name = loop.run_until_complete(asyncio.wait_for(test(), 1))
@@ -74,8 +70,7 @@ class TestThreadPooled(unittest.TestCase):
             loop_getter=loop_getter,
             loop_getter_need_context=True
         )
-        @asyncio.coroutine
-        def test(*args, **kwargs):
+        async def test(*args, **kwargs):
             return threading.current_thread().name
 
         pooled_name = loop.run_until_complete(
@@ -87,8 +82,7 @@ class TestThreadPooled(unittest.TestCase):
 class TestAsyncIOTask(unittest.TestCase):
     def test_default(self):
         @threaded.asynciotask
-        @asyncio.coroutine
-        def test():
+        async def test():
             return 'test'
 
         loop = asyncio.get_event_loop()
@@ -97,8 +91,7 @@ class TestAsyncIOTask(unittest.TestCase):
 
     def test_construct(self):
         @threaded.asynciotask()
-        @asyncio.coroutine
-        def test():
+        async def test():
             return 'test'
 
         loop = asyncio.get_event_loop()

--- a/test/test_gevent_threadpooled.py
+++ b/test/test_gevent_threadpooled.py
@@ -12,7 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from os import cpu_count
+import os
 import threading
 import unittest
 
@@ -52,7 +52,7 @@ class TestThreadPooled(unittest.TestCase):
 
         self.assertEqual(
             thread_pooled.executor.maxsize,
-            (cpu_count() or 1) * 5
+            (os.cpu_count() or 1) * 5
         )
 
         thread_pooled.configure(max_workers=2)

--- a/test/test_gevent_threadpooled.py
+++ b/test/test_gevent_threadpooled.py
@@ -38,14 +38,6 @@ class TestThreadPooled(unittest.TestCase):
         pooled_name = test().wait()
         self.assertNotEqual(pooled_name, threading.current_thread().name)
 
-    def test_thread_pooled_default_async(self):
-        @threaded.gthreadpooled
-        async def test():
-            return threading.current_thread().name
-
-        pooled_name = test().wait()
-        self.assertNotEqual(pooled_name, threading.current_thread().name)
-
     def test_thread_pooled_construct(self):
         @threaded.gthreadpooled()
         def test():

--- a/test/test_pooled_coroutine.py
+++ b/test/test_pooled_coroutine.py
@@ -33,26 +33,10 @@ class TestThreadPooled(unittest.TestCase):
         pooled_name = concurrent.futures.wait([test()])
         self.assertNotEqual(pooled_name, threading.current_thread().name)
 
-    def test_thread_pooled_default_a(self):
-        @threaded.threadpooled
-        async def test():
-            return threading.current_thread().name
-
-        pooled_name = concurrent.futures.wait([test()])
-        self.assertNotEqual(pooled_name, threading.current_thread().name)
-
     def test_thread_pooled_construct(self):
         @threaded.threadpooled()
         @asyncio.coroutine
         def test():
-            return threading.current_thread().name
-
-        pooled_name = concurrent.futures.wait([test()])
-        self.assertNotEqual(pooled_name, threading.current_thread().name)
-
-    def test_thread_pooled_construct_a(self):
-        @threaded.threadpooled()
-        async def test():
             return threading.current_thread().name
 
         pooled_name = concurrent.futures.wait([test()])
@@ -69,32 +53,12 @@ class TestThreadPooled(unittest.TestCase):
         pooled_name = loop.run_until_complete(asyncio.wait_for(test(), 1))
         self.assertNotEqual(pooled_name, threading.current_thread().name)
 
-    def test_thread_pooled_loop_a(self):
-        loop = asyncio.get_event_loop()
-
-        @threaded.threadpooled(loop_getter=loop)
-        async def test():
-            return threading.current_thread().name
-
-        pooled_name = loop.run_until_complete(asyncio.wait_for(test(), 1))
-        self.assertNotEqual(pooled_name, threading.current_thread().name)
-
     def test_thread_pooled_loop_getter(self):
         loop = asyncio.get_event_loop()
 
         @threaded.threadpooled(loop_getter=asyncio.get_event_loop)
         @asyncio.coroutine
         def test():
-            return threading.current_thread().name
-
-        pooled_name = loop.run_until_complete(asyncio.wait_for(test(), 1))
-        self.assertNotEqual(pooled_name, threading.current_thread().name)
-
-    def test_thread_pooled_loop_getter_a(self):
-        loop = asyncio.get_event_loop()
-
-        @threaded.threadpooled(loop_getter=asyncio.get_event_loop)
-        async def test():
             return threading.current_thread().name
 
         pooled_name = loop.run_until_complete(asyncio.wait_for(test(), 1))
@@ -119,24 +83,6 @@ class TestThreadPooled(unittest.TestCase):
         )
         self.assertNotEqual(pooled_name, threading.current_thread().name)
 
-    def test_thread_pooled_loop_getter_context_a(self):
-        loop = asyncio.get_event_loop()
-
-        def loop_getter(target):
-            return target
-
-        @threaded.threadpooled(
-            loop_getter=loop_getter,
-            loop_getter_need_context=True
-        )
-        async def test(*args, **kwargs):
-            return threading.current_thread().name
-
-        pooled_name = loop.run_until_complete(
-            asyncio.wait_for(test(loop), 1)
-        )
-        self.assertNotEqual(pooled_name, threading.current_thread().name)
-
 
 class TestAsyncIOTask(unittest.TestCase):
     def test_default(self):
@@ -149,26 +95,8 @@ class TestAsyncIOTask(unittest.TestCase):
         res = loop.run_until_complete(asyncio.wait_for(test(), 1))
         self.assertEqual(res, 'test')
 
-    def test_default_a(self):
-        @threaded.asynciotask
-        async def test():
-            return 'test'
-
-        loop = asyncio.get_event_loop()
-        res = loop.run_until_complete(asyncio.wait_for(test(), 1))
-        self.assertEqual(res, 'test')
-
     def test_construct(self):
         @threaded.asynciotask()
         @asyncio.coroutine
         def test():
             return 'test'
-
-    def test_construct_a(self):
-        @threaded.asynciotask()
-        async def test():
-            return 'test'
-
-        loop = asyncio.get_event_loop()
-        res = loop.run_until_complete(asyncio.wait_for(test(), 1))
-        self.assertEqual(res, 'test')

--- a/threaded/__init__.py
+++ b/threaded/__init__.py
@@ -14,7 +14,7 @@
 
 """threaded module."""
 
-import typing  # noqa  # pylint: disable=unused-import
+import typing
 
 # pylint: disable=no-name-in-module
 from ._asynciotask import AsyncIOTask, asynciotask

--- a/threaded/_threadpooled.py
+++ b/threaded/_threadpooled.py
@@ -147,13 +147,13 @@ class ThreadPooled(_base_threaded.APIPooled):
     def _get_function_wrapper(
         self,
         func: typing.Callable
-    ) -> typing.Callable[..., concurrent.futures.Future]:
+    ) -> typing.Callable[..., typing.Union[concurrent.futures.Future, 'typing.Awaitable']]:
         """Here should be constructed and returned real decorator.
 
         :param func: Wrapped function
         :type func: typing.Callable
         :return: wrapped coroutine or function
-        :rtype: typing.Callable[..., concurrent.futures.Future]
+        :rtype: typing.Callable[..., typing.Union[typing.Awaitable, concurrent.futures.Future]]
         """
         prepared = self._await_if_required(func)
 
@@ -163,7 +163,10 @@ class ThreadPooled(_base_threaded.APIPooled):
         def wrapper(
             *args: typing.Any,
             **kwargs: typing.Any
-        ) -> typing.Union[concurrent.futures.Future, typing.Callable[..., concurrent.futures.Future]]:
+        ) -> typing.Union[
+            concurrent.futures.Future, 'typing.Awaitable',
+            typing.Callable[..., typing.Union[concurrent.futures.Future, 'typing.Awaitable']]
+        ]:
             loop = self._get_loop(*args, **kwargs)
 
             if loop is None:
@@ -184,7 +187,10 @@ class ThreadPooled(_base_threaded.APIPooled):
         self,
         *args: typing.Union[typing.Callable, typing.Any],
         **kwargs: typing.Any
-    ) -> typing.Union[concurrent.futures.Future, typing.Callable[..., concurrent.futures.Future]]:
+    ) -> typing.Union[
+        concurrent.futures.Future, 'typing.Awaitable',
+        typing.Callable[..., typing.Union[concurrent.futures.Future, 'typing.Awaitable']]
+    ]:
         """Callable instance."""
         return super(ThreadPooled, self).__call__(*args, **kwargs)  # type: ignore
 
@@ -256,7 +262,10 @@ def threadpooled(  # noqa: F811
         asyncio.AbstractEventLoop
     ] = None,
     loop_getter_need_context: bool = False
-) -> typing.Union[ThreadPooled, typing.Callable[..., concurrent.futures.Future]]:
+) -> typing.Union[
+    ThreadPooled,
+    typing.Callable[..., typing.Union[concurrent.futures.Future, 'typing.Awaitable']]
+]:
     """Post function to ThreadPoolExecutor.
 
     :param func: function to wrap

--- a/threaded/_threadpooled.py
+++ b/threaded/_threadpooled.py
@@ -304,8 +304,8 @@ class ThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
 
     def __init__(
         self,
-        max_workers=None  # type: typing.Optional[int]
-    ):  # type: (...) -> None
+        max_workers: typing.Optional[int]=None
+    ) -> None:
         """Override init due to difference between Python <3.5 and 3.5+.
 
         :param max_workers: Maximum workers allowed. If none: cpu_count() or 1) * 5

--- a/threaded/_threadpooled.py
+++ b/threaded/_threadpooled.py
@@ -304,7 +304,7 @@ class ThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
 
     def __init__(
         self,
-        max_workers: typing.Optional[int]=None
+        max_workers: typing.Optional[int] = None
     ) -> None:
         """Override init due to difference between Python <3.5 and 3.5+.
 

--- a/tools/build-wheels.sh
+++ b/tools/build-wheels.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-PYTHON_VERSIONS="cp35-cp35m cp36-cp36m cp37-cp37m"
+PYTHON_VERSIONS="cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m"
 
 # Avoid creation of __pycache__/*.py[c|o]
 export PYTHONDONTWRITEBYTECODE=1

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ commands =
 commands = {posargs:}
 
 [tox:travis]
+3.4 = py34,
 3.5 = py35,
 3.6 = py36,
 3.7 = py37,

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 minversion = 2.0
-envlist = pep8, pylint, mypy, bandit, pep257, py{35,36,37,py3}, docs, py{35,36,37}-nocov
+envlist = pep8, pylint, mypy, bandit, pep257, py{34,35,36,37,py3}, docs, py{34,35,36,37}-nocov
 skipsdist = True
 skip_missing_interpreters = True
 
@@ -25,6 +25,13 @@ deps =
 commands =
     py.test --junitxml=unit_result.xml --cov-config .coveragerc --cov-report html --cov=threaded {posargs:test}
     coverage report --fail-under 90
+
+[testenv:py34-nocov]
+usedevelop = False
+commands =
+    python setup.py bdist_wheel
+    pip install threaded --no-index -f dist
+    py.test -vv {posargs:test}
 
 [testenv:py35-nocov]
 usedevelop = False


### PR DESCRIPTION
support python 3.4 (and allow to limit legacy branch to py27 only)

* split tests by python 3.4 compatible and 3.5+ compatible